### PR TITLE
Create configuration for Stale Bot

### DIFF
--- a/stale.yml
+++ b/stale.yml
@@ -1,0 +1,25 @@
+daysUntilStale: 180
+daysUntilClose: 180
+exemptLabels:
+ - BFP
+ - Pinned
+staleLabel: Stale
+only: issues
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  The issue was automatically closed due to inactivity. If you found some new details please comment on the issue so that maintainers can re-open it.
+
+markComment: |
+  Hello there!
+  
+  It looks like this issue hasn't progressed lately. There are so many issues that we just can't deal them all within a reasonable timeframe.
+  
+  There are a few things you could help to get things rolling on this issue (this is an automated message, so expect that some of these are already in use):
+  
+   * Check if the issue is still valid for the latest version. There are many duplicates in our issue tracker, so it is possible that the issue is already tackled.
+   * Provide more details how to reproduce the issue.
+   * Explain why it is important to get this issue fixed and politely draw others attention to it e.g. via the forum or social media.
+   * Add a reduced test case about the issue, so it is easier for somebody to start working on a solution.
+   * If the issue is clearly a bug, use the [Warranty](https://vaadin.com/pricing) in your Vaadin subscription to raise its priority.
+  
+  Thanks again for your contributions! Even though we haven't been able to get this issue fixed, we hope you to report your findings and enhancement ideas in the future too!

--- a/stale.yml
+++ b/stale.yml
@@ -3,6 +3,7 @@ daysUntilClose: 180
 exemptLabels:
  - BFP
  - Pinned
+ - Epic
 staleLabel: Stale
 only: issues
 # Comment to post when closing a stale Issue or Pull Request.


### PR DESCRIPTION
Initial commit for configuration. Marks issues stale after 1/2 years of inactivity, and marks them as closed 1/2 years after that.