### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This is a public repository for Vaadin Designer issues.
 
 [Report an issue](https://github.com/vaadin/designer/issues/new) and fill in the relevant information. Especially the **Steps to reproduce** is important, since it helps us pinpoint and test the issue. If you find issues that are important to you, please vote for them by reacting with :+1:.
 
-For more information about the product itself, please visit the product homepage https://vaadin.com/designer or our [documentation](https://vaadin.com/docs/v10/designer/designer-overview.html).
+For more information about the product itself, please visit the product homepage https://vaadin.com/designer or our [documentation](https://vaadin.com/docs/designer/getting-started/designer-overview.html).


### PR DESCRIPTION
Update the documentation link with a generic one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/designer/1993)
<!-- Reviewable:end -->
